### PR TITLE
Upgrade deployment to Maven Central to use new plugin from Sonatype

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,9 @@ jobs:
     name: build java ${{ matrix.java }}
     steps:
       - name: Checkout reposistory
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           java-version: ${{ matrix.java }}
           distribution: temurin
@@ -23,49 +23,41 @@ jobs:
       - name: Build with Maven
         run: mvn -B package --no-transfer-progress --file pom.xml
 
-  makeversion:
-    if: github.ref != 'refs/heads/main'
+  publish:
     needs: build
+    name: Publish ${{ github.ref_name }}
     runs-on: ubuntu-latest
-    name: Create version
-    outputs:
-      version: ${{ steps.version.outputs.version }}
     steps:
-      - name: Decide on build version
-        id: version
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set up Java
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: "maven"
+          gpg-private-key: ${{ secrets.MAVEN_CENTRAL_SIGNING_KEY_PRIVATE }}
+          server-id: central
+          server-username: MAVEN_CENTRAL_TOKEN_USERNAME
+          server-password: MAVEN_CENTRAL_TOKEN_PASSWORD
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+      - name: Activate Artifact Signing and Version Suffix
         run: |
-          if [[ $GITHUB_REF == *"tags"* ]]; then
-            TAG=${GITHUB_REF#refs/tags/}
+          profiles="build-sources-and-javadoc,deploy-to-maven-central"
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            profiles="$profiles,sign-artifacts"
+            version_suffix=""
           else
-            TAG=${GITHUB_REF#refs/heads/}-SNAPSHOT
+            version_suffix="-SNAPSHOT"
           fi
-          echo "version=${TAG//\//-}" >> $GITHUB_OUTPUT
-
-  deploy_snapshot:
-    if: startsWith(github.ref, 'refs/heads/')
-    needs: makeversion
-    runs-on: ubuntu-latest
-
-    name: Deploy snapshot
-    steps:
-      - uses: actions/checkout@v4
-      - uses: digipost/action-maven-publish@1.3.2
-        with:
-          sonatype_secrets: ${{ secrets.sonatype_secrets }}
-          release_version: ${{ needs.makeversion.outputs.version }}
-          perform_release: false
-
-  release:
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
-    needs: makeversion
-    name: Release to Sonatype
-    steps:
-      - name: Check out Git repository
-        uses: actions/checkout@v4
-      - name: Release to Central Repository
-        uses: digipost/action-maven-publish@1.3.2
-        with:
-          sonatype_secrets: ${{ secrets.sonatype_secrets }}
-          release_version: ${{ needs.makeversion.outputs.version }}
-          perform_release: true
+          echo "MAVEN_PROFILES=$profiles" >> $GITHUB_ENV
+          version="${GITHUB_REF_NAME}${version_suffix}"
+          echo "VERSION=$version" >> $GITHUB_ENV
+      - name: Set Maven version
+        run: mvn --batch-mode --no-transfer-progress versions:set -DnewVersion=${VERSION}
+      - name: Build and deploy to Maven Central
+        run: |
+          mvn --batch-mode --no-transfer-progress --activate-profiles ${MAVEN_PROFILES} deploy
+        env:
+          MAVEN_CENTRAL_TOKEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_TOKEN_USERNAME }}
+          MAVEN_CENTRAL_TOKEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_TOKEN_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_CENTRAL_SIGNING_KEY_PASSPHRASE }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target/
 .classpath
 .settings
 .project
+.vscode/settings.json

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -10,6 +10,9 @@
     </parent>
 
     <artifactId>peppol-bis-billing-3-generator-api</artifactId>
+
+    <name>${project.artifactId}</name>
+
     <description>Peppol BIS Billing 3 generator Api</description>
 
     <dependencies>

--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -10,6 +10,8 @@
     </parent>
 
     <artifactId>peppol-bis-billing-3-generator-domain</artifactId>
+
+    <name>${project.artifactId}</name>
     <description>Peppol BIS Billing 3 generator Domain</description>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>no.digipost</groupId>
         <artifactId>digipost-open-super-pom</artifactId>
-        <version>13</version>
+        <version>14</version>
     </parent>
 
     <artifactId>peppol-bis-billing-3-generator-parent</artifactId>
@@ -70,11 +70,11 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.1.4</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.3.1</version>
+                    <version>3.5.0</version>
                     <configuration>
                         <filesets>
                             <fileset>
@@ -88,16 +88,16 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.6.0</version>
+                    <version>3.8.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.1.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.16.1</version>
+                    <version>2.18.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/validation/pom.xml
+++ b/validation/pom.xml
@@ -10,6 +10,8 @@
     </parent>
 
     <artifactId>peppol-bis-billing-3-generator-validation</artifactId>
+
+    <name>${project.artifactId}</name>
     <description>Peppol BIS Billing 3 generator Validation</description>
 
     <dependencies>


### PR DESCRIPTION
Upgrade most plugins to latest release.  Rewrite the publishing job to deploy directly to Maven Central (was: using obsolete GitHub action) with new plugin configured in the  parent POM and using more recent support in setup-java for deployment settings in Maven.